### PR TITLE
Create indexes as non-unique for non-unique columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # sparx_ea_oracle_tuning
 Oracle tuning tips for Sparx Enterprise Architect
 - optimize indexes to try eliminate bad design
-- tell Oracle use statement cache for non bindig based sql
+- tell Oracle to use statement cache for non-binding-based SQLs

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # sparx_ea_oracle_tuning
 Oracle tuning tips for Sparx Enterprise Architect
 - optimize indexes to try eliminate bad design
-- tell Oracle to use statement cache for non-binding-based SQLs
+- tell Oracle to use statement cache for non-binding-based SQL queries

--- a/t_connector_tuning.sql
+++ b/t_connector_tuning.sql
@@ -1,6 +1,6 @@
 -- UC???: Speed up found starting and ending object relations in manual operation.
 drop index IDX$CON$START_END;
-create unique index IDX$CON$START_END on T_CONNECTOR (START_OBJECT_ID, END_OBJECT_ID) compress 1  reverse;
+create index IDX$CON$START_END on T_CONNECTOR (START_OBJECT_ID, END_OBJECT_ID) compress 1  reverse;
 
 -- UC002
 drop index IDX$CON$ENDOBJ_CON_STRTOBJ_DID;

--- a/t_operationparams_tuning.sql
+++ b/t_operationparams_tuning.sql
@@ -1,10 +1,10 @@
 -- UC???
 drop index IDX$OPERP$OBJID_CLASFR;
-create unique index IDX$OPERP$OBJID_CLASFR on T_OPERATIONPARAMS (operationid, CLASSIFIER) reverse;
+create index IDX$OPERP$OBJID_CLASFR on T_OPERATIONPARAMS (operationid, CLASSIFIER) reverse;
 
 -- UC001
 drop index IDX$OPERP$CLASFR_OBJID;
-create unique index IDX$OPERP$CLASFR_OBJID on T_OPERATIONPARAMS (CLASSIFIER, operationid) compress 1 reverse;
+create index IDX$OPERP$CLASFR_OBJID on T_OPERATIONPARAMS (CLASSIFIER, operationid) compress 1 reverse;
 
 -- UC004
 drop index IDX$OPERP$OPERID_GUID;


### PR DESCRIPTION
I found out that original indexes cannot be created (for our EA13 with data) since Oracle end with ORA-01452 (duplicate values found).